### PR TITLE
Log number of parameters of a model

### DIFF
--- a/examples/controlnet/train_controlnet_mlflow.py
+++ b/examples/controlnet/train_controlnet_mlflow.py
@@ -64,6 +64,14 @@ check_min_version("0.17.0.dev0")
 logger = get_logger(__name__)
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def image_grid(imgs, rows, cols):
     assert len(imgs) == rows * cols
 
@@ -1023,6 +1031,11 @@ def main(args):
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+    num_params = get_num_parameters(unet)
+    num_params += get_num_parameters(vae)
+    num_params += get_num_parameters(text_encoder)
+    num_params += get_num_parameters(controlnet)
+    mlflow.log_param('num_params', num_params)
     start_time = time.time()
     throughput_list = []
     for epoch in range(first_epoch, args.num_train_epochs):

--- a/examples/dreambooth/train_dreambooth_mlflow.py
+++ b/examples/dreambooth/train_dreambooth_mlflow.py
@@ -98,6 +98,14 @@ DreamBooth for the text encoder was enabled: {train_text_encoder}.
         f.write(yaml + model_card)
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def log_validation(
     text_encoder, tokenizer, unet, vae, args, accelerator, weight_dtype, epoch, prompt_embeds, negative_prompt_embeds
 ):
@@ -1157,6 +1165,10 @@ def main(args):
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+
+    num_params = get_num_parameters(unet)
+    num_params += get_num_parameters(text_encoder)
+    mlflow.log_param('num_params', num_params)
     start_time = time.time()
     throughput_list = []
     for epoch in range(first_epoch, args.num_train_epochs):

--- a/examples/instruct_pix2pix/train_instruct_pix2pix_mlflow.py
+++ b/examples/instruct_pix2pix/train_instruct_pix2pix_mlflow.py
@@ -65,6 +65,14 @@ DATASET_NAME_MAPPING = {
 WANDB_TABLE_COL_NAMES = ["original_image", "edited_image", "edit_prompt"]
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Simple example of a training script for InstructPix2Pix.")
     parser.add_argument(
@@ -800,6 +808,10 @@ def main():
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+    num_params = get_num_parameters(text_encoder)
+    num_params += get_num_parameters(vae)
+    num_params += get_num_parameters(unet)
+    mlflow.log_param('num_params', num_params)
     start_time = time.time()
     throughput_list = []
     for epoch in range(first_epoch, args.num_train_epochs):

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,10 +1,6 @@
 git+https://github.com/moreh-dev/diffusers.git@main
 git+https://github.com/huggingface/accelerate@v0.21.0
-torchvision>=0.11.0
-protobuf>=3.19.6,<4
-transformers>=4.25.1
 ftfy==6.1.1
-tensorboard==2.13.0
 Jinja2==3.1.2
 matplotlib==3.7.2
 opencv-python>=4.8.0

--- a/examples/text_to_image/train_text_to_image_mlflow.py
+++ b/examples/text_to_image/train_text_to_image_mlflow.py
@@ -65,6 +65,14 @@ DATASET_NAME_MAPPING = {
 }
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def log_validation(vae, text_encoder, tokenizer, unet, args, accelerator, weight_dtype, epoch):
     logger.info("Running validation... ")
 
@@ -837,6 +845,11 @@ def main():
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+
+    num_params = get_num_parameters(text_encoder)
+    num_params += get_num_parameters(vae)
+    num_params += get_num_parameters(unet)
+    mlflow.log_param('num_params', num_params)
     start_time = time.time()
     throughput_list = []
     for epoch in range(first_epoch, args.num_train_epochs):

--- a/examples/textual_inversion/textual_inversion_mlflow.py
+++ b/examples/textual_inversion/textual_inversion_mlflow.py
@@ -86,6 +86,14 @@ check_min_version("0.17.0.dev0")
 logger = get_logger(__name__)
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def save_model_card(repo_id: str, images=None, base_model=str, repo_folder=None):
     img_str = ""
     for i, image in enumerate(images):
@@ -843,6 +851,10 @@ def main():
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+    num_params = get_num_parameters(text_encoder)
+    num_params += get_num_parameters(vae)
+    num_params += get_num_parameters(unet)
+    mlflow.log_param('num_params', num_params)
     start_time = time.time()
     throughput_list = []
     for epoch in range(first_epoch, args.num_train_epochs):

--- a/examples/unconditional_image_generation/train_unconditional_mlflow.py
+++ b/examples/unconditional_image_generation/train_unconditional_mlflow.py
@@ -38,6 +38,14 @@ check_min_version("0.17.0.dev0")
 logger = get_logger(__name__, log_level="INFO")
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def _extract_into_tensor(arr, timesteps, broadcast_shape):
     """
     Extract values from a 1-D numpy array for a batch of indices.
@@ -578,6 +586,9 @@ def main(args):
     # mlflow_runner = mlflow.start_run(run_name=f'bs{args.train_batch_size}_{current_datetime}', experiment_id=experiment.experiment_id)
 
     mlflow.start_run()
+
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
 
     start_time = time.time()
     throughput_list = []


### PR DESCRIPTION
### Background

We currently include the size information in the model name and use it to differentiate between model sizes. However, I think it's too hard to tell what size this model is with a size name like '-base', '-large', '-b0' etc.

Even, nowadays, the number of parameters, such as 7b, is used as a suffix to express the size of the model. This numbering tells us more information. How much GPU memory usage will be occupied when a model is loaded. It also makes it easier to compare model sizes between similar types of models, such as trasnformers models.

### What this PR does

- calculate the number of parameters of a model and log using mlflow.log_param().
- Diffuser models combined multiple models, so calculate total parameters of these all models.