### PR TITLE
add efficient_unet and update others

### DIFF
--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -43,6 +43,7 @@ else:
         Transformer2DModel,
         UNet1DModel,
         UNet2DConditionModel,
+        EfficientUNet2DConditionModel,
         UNet2DModel,
         UNet3DConditionModel,
         VQModel,

--- a/src/diffusers/models/__init__.py
+++ b/src/diffusers/models/__init__.py
@@ -26,6 +26,7 @@ if is_torch_available():
     from .unet_1d import UNet1DModel
     from .unet_2d import UNet2DModel
     from .unet_2d_condition import UNet2DConditionModel
+    from .unet_2d_condition_efficient import EfficientUNet2DConditionModel
     from .unet_3d_condition import UNet3DConditionModel
     from .vq_model import VQModel
 

--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -402,9 +402,9 @@ class AttentionPooling(nn.Module):
         super().__init__()
         self.dtype = dtype
         self.positional_embedding = nn.Parameter(torch.randn(1, embed_dim) / embed_dim**0.5)
-        self.k_proj = nn.Linear(embed_dim, embed_dim, dtype=self.dtype)
-        self.q_proj = nn.Linear(embed_dim, embed_dim, dtype=self.dtype)
-        self.v_proj = nn.Linear(embed_dim, embed_dim, dtype=self.dtype)
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
         self.num_heads = num_heads
         self.dim_per_head = embed_dim // self.num_heads
 

--- a/src/diffusers/models/transformer_2d.py
+++ b/src/diffusers/models/transformer_2d.py
@@ -215,6 +215,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
         self,
         hidden_states,
         encoder_hidden_states=None,
+        encoder_attention_mask=None,
         timestep=None,
         class_labels=None,
         cross_attention_kwargs=None,
@@ -265,6 +266,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             hidden_states = block(
                 hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
                 timestep=timestep,
                 cross_attention_kwargs=cross_attention_kwargs,
                 class_labels=class_labels,

--- a/src/diffusers/models/unet_2d_condition_efficient.py
+++ b/src/diffusers/models/unet_2d_condition_efficient.py
@@ -28,7 +28,9 @@ from .modeling_utils import ModelMixin
 from .unet_2d_blocks import (
     CrossAttnDownBlock2D,
     CrossAttnUpBlock2D,
+    EfficientCrossAttnDownBlock2D,
     DownBlock2D,
+    EfficientDownBlock2D,
     UNetMidBlock2DCrossAttn,
     UNetMidBlock2DSimpleCrossAttn,
     UpBlock2D,
@@ -51,7 +53,7 @@ class UNet2DConditionOutput(BaseOutput):
     sample: torch.FloatTensor
 
 
-class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin):
+class EfficientUNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin):
     r"""
     UNet2DConditionModel is a conditional 2D UNet model that takes in a noisy sample, conditional state, and a timestep
     and returns sample shaped output.
@@ -349,7 +351,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 in_channels=input_channel,
                 out_channels=output_channel,
                 temb_channels=blocks_time_embed_dim,
-                add_downsample=not is_final_block,
+                add_downsample=True,
                 resnet_eps=norm_eps,
                 resnet_act_fn=act_fn,
                 resnet_groups=norm_num_groups,
@@ -424,11 +426,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             input_channel = reversed_block_out_channels[min(i + 1, len(block_out_channels) - 1)]
 
             # add upsample block for all BUT final layer
-            if not is_final_block:
-                add_upsample = True
-                self.num_upsamplers += 1
-            else:
-                add_upsample = False
+            self.num_upsamplers += 1
 
             up_block = get_up_block(
                 up_block_type,
@@ -437,7 +435,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 out_channels=output_channel,
                 prev_output_channel=prev_output_channel,
                 temb_channels=blocks_time_embed_dim,
-                add_upsample=add_upsample,
+                add_upsample=True,
                 resnet_eps=norm_eps,
                 resnet_act_fn=act_fn,
                 resnet_groups=norm_num_groups,


### PR DESCRIPTION
- Add `EfficientUNet2DConditionModel` and related blocks
    -   Memory (for forward-backward) efficient UNet for super-resolution tasks, originally proposed by Google (Imagen)
- Remove type keyword for `Linear(*, dtype=)` since it raises error for the old version of torch (Linear module does not have dtype kwarg
- Add encoder_attention_mask to the `UNet2DConditionModel` and related blocks
---
- (MAF specific) bypassing the error in `torch.clamp`---currently, `torch.clamp` only allows tensor datatype, not float---with minimum and maximum