### PR TITLE
[Bug] Fix bug requirements_moreh.txt tensorboard version too high

### DIFF
--- a/requirements_moreh.txt
+++ b/requirements_moreh.txt
@@ -6,7 +6,6 @@ Jinja2==3.1.2
 matplotlib==3.7.2
 opencv-python>=4.8.0
 datasets==2.14.6
-tensorboard
+tensorboard==2.11.2
 torchmetrics
-protobuf>=3.19.6,<4
 pytest==7.4.2


### PR DESCRIPTION
## Background

When I ran diffusers benchmark on testbench, I found out that my runs didn't use GPU for training. After some inspections, it turned out that we didn't set a specific version for `tensorboard`, which now will automatically install `tensorboard==2.14.0`, which has `google-auth-oauthlib<1.1,>=0.5` and `protobuf>=3.19.6`. But the current version of MAF is `24.7.0`, which needs `google-auth-oauthlib==0.4.6` and `protobuf==3.13.0`.

## PR Content

- Set `tensorboard` version to `2.11.2`, which is compatible with MAF `24.7.0`
- Remove `protobuf>=3.19.6,<4`